### PR TITLE
Added the Activity command

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -57,7 +57,7 @@ export default async (settings: BotSettings) => {
     });
 
     client.on("interactionCreate", async (interaction) => {
-        handler(settings, interaction);
+        handler(settings, interaction, client);
     });
 
     client.on("voiceStateUpdate", async (...args) => {

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -1,4 +1,4 @@
-import { Client, CommandInteractionOptionResolver, REST, Routes, SlashCommandBuilder } from "discord.js";
+import { Client, CommandInteractionOptionResolver, REST, Routes, SlashCommandBuilder, PresenceStatusData } from "discord.js";
 import Command from "./command/command";
 import handler from "./interaction/handler";
 import Module from "./module/module";
@@ -10,6 +10,9 @@ export class BotSettings {
 };
 
 export default async (settings: BotSettings) => {
+
+    console.log("Bot is starting...");
+
     const client = new Client({
         intents: [
             "Guilds",
@@ -38,7 +41,7 @@ export default async (settings: BotSettings) => {
             Routes.applicationCommands(
                 client.user.id
             ),
-            { 
+            {
                 body: settings.commands.map(command => command.builder.toJSON())
             }
         );
@@ -53,6 +56,18 @@ export default async (settings: BotSettings) => {
 
                 settings.modules = settings.modules.filter(m => m !== module);
             }
+        }
+
+        console.log("Loading and setting activity...");
+        if (process.env.ACTIVITY_TYPE && process.env.ACTIVITY_STATUS && process.env.ACTIVITY_TEXT) {
+            try {
+                client.user?.setPresence({ activities: [{ name: process.env.ACTIVITY_TEXT, type: +process.env.ACTIVITY_TYPE }], status: process.env.ACTIVITY_STATUS as PresenceStatusData });
+                console.log("Bot activity status loaded.");
+            } catch {
+                console.log("Couldn't load saved activity - there's some erorr in the file/syntax");
+            }
+        } else {
+            console.log("Couldn't find saved activity.");
         }
     });
 

--- a/src/command/command.ts
+++ b/src/command/command.ts
@@ -1,4 +1,4 @@
-import { CommandInteraction, PermissionFlags, PermissionResolvable, SlashCommandBuilder, SlashCommandSubcommandBuilder } from "discord.js";
+import { CommandInteraction, PermissionFlags, PermissionResolvable, SlashCommandBuilder, SlashCommandSubcommandBuilder, Client } from "discord.js";
 import {BotSettings} from "../bot";
 
 export default interface Command {
@@ -14,5 +14,5 @@ export default interface Command {
      * Gets called when the command is executed.
      * @param interaction The interaction that triggered the command.
      */
-    call: (interaction: CommandInteraction, settings: BotSettings) => Promise<void>;
+    call: (interaction: CommandInteraction, settings: BotSettings, client: Client) => Promise<void>;
 }

--- a/src/command/commands/activity.ts
+++ b/src/command/commands/activity.ts
@@ -15,12 +15,12 @@ export default {
             .setRequired(true)
             .setDescription("Typ aktivity")
             .addChoices(
-                { name: "Playing", value: 0 },
-                { name: "Competing in", value: 5 },
+                { name: "Playing", value: 0, name_localizations: { cs: "Hraje" } },
+                { name: "Competing in", value: 5, name_localizations: { cs: "Soutěží v" }  },
                 // { name: "Custom", value: 4 }, //Custom status is not available for bots (yet? hopefully)
-                { name: "Listening to", value: 2 },
+                { name: "Listening to", value: 2, name_localizations: { cs: "Poslouchá" }  },
                 // { name: "Streaming", value: 1 }, //apparently doesn't work for bots either
-                { name: "Watching", value: 3 },
+                { name: "Watching", value: 3, name_localizations: { cs: "Sleduje" }  },
             )
         )
         .addStringOption(option => option
@@ -62,9 +62,9 @@ export default {
         fs.readFile(".env", (err, data) => {
             if (err) throw err;
             let envLines = data.toString().split('\n');
-            
+
             envLines = envLines.filter(x => !x.includes("ACTIVITY")); //filter out all the lines about activity to delete (and esentially rewrite them)
-            
+
             envLines.push(`ACTIVITY_TYPE=${activityType}`);
             envLines.push(`ACTIVITY_STATUS=${activityStatus}`);
             envLines.push(`ACTIVITY_TEXT='${activityText.replace("'", "\\'")}'`);

--- a/src/command/commands/activity.ts
+++ b/src/command/commands/activity.ts
@@ -1,6 +1,8 @@
 import { ActivityType, Client, CommandInteraction, DiscordjsError, PresenceStatusData, SlashCommandBuilder } from "discord.js"
 import Command from "../command"
 import { BotSettings } from "../../bot";
+import * as fs from "fs";
+
 
 export default {
     requiredPermissions: ["Administrator"],
@@ -37,10 +39,7 @@ export default {
                 { name: "Do Not Disturb", value: "dnd" },
             )
         ),
-
-    // PresenceData.status: online, idle, invisible, dnd
-    // ActivitiesOptions.type: Competing, Custom, Listening, Playing, Streaming, Watching
-
+    //todo: add translations to the command options
 
     call: async (interaction: CommandInteraction, settings: BotSettings, client: Client) => {
 
@@ -58,6 +57,20 @@ export default {
         client.user?.setPresence({ activities: [{ name: activityText, type: activityType }], status: activityStatus as PresenceStatusData });
 
         await interaction.reply({ content: "Aktivita byla úspěšně nastavena!", ephemeral: true });
+
+        //saving activity
+        fs.readFile(".env", (err, data) => {
+            if (err) throw err;
+            let envLines = data.toString().split('\n');
+            
+            envLines = envLines.filter(x => !x.includes("ACTIVITY")); //filter out all the lines about activity to delete (and esentially rewrite them)
+            
+            envLines.push(`ACTIVITY_TYPE=${activityType}`);
+            envLines.push(`ACTIVITY_STATUS=${activityStatus}`);
+            envLines.push(`ACTIVITY_TEXT='${activityText.replace("'", "\\'")}'`);
+
+            fs.writeFileSync(".env", envLines.join('\n'));
+        });
     }
 
 } as Command

--- a/src/command/commands/activity.ts
+++ b/src/command/commands/activity.ts
@@ -1,0 +1,63 @@
+import { ActivityType, Client, CommandInteraction, DiscordjsError, PresenceStatusData, SlashCommandBuilder } from "discord.js"
+import Command from "../command"
+import { BotSettings } from "../../bot";
+
+export default {
+    requiredPermissions: ["Administrator"],
+
+    builder: new SlashCommandBuilder()
+        .setName("activity")
+        .setDescription("Nastaví aktivitu bota.")
+        .addIntegerOption(option => option
+            .setName("type")
+            .setRequired(true)
+            .setDescription("Typ aktivity")
+            .addChoices(
+                { name: "Playing", value: 0 },
+                { name: "Competing in", value: 5 },
+                // { name: "Custom", value: 4 }, //Custom status is not available for bots (yet? hopefully)
+                { name: "Listening to", value: 2 },
+                // { name: "Streaming", value: 1 }, //apparently doesn't work for bots either
+                { name: "Watching", value: 3 },
+            )
+        )
+        .addStringOption(option => option
+            .setName("activitytext")
+            .setDescription("Text, který se má ukazovat v aktivitě bota")
+            .setRequired(true)
+        )
+        .addStringOption(option => option
+            .setName("status")
+            .setRequired(false)
+            .setDescription("Status aktivity")
+            .addChoices(
+                { name: "Online", value: "online" },
+                { name: "Idle", value: "idle" },
+                { name: "Invisible", value: "invisible" },
+                { name: "Do Not Disturb", value: "dnd" },
+            )
+        ),
+
+    // PresenceData.status: online, idle, invisible, dnd
+    // ActivitiesOptions.type: Competing, Custom, Listening, Playing, Streaming, Watching
+
+
+    call: async (interaction: CommandInteraction, settings: BotSettings, client: Client) => {
+
+        //shouldn't really happen, but TS screams at me violently if it's not here
+        if (client.user == null) {
+            console.log("Client.user is null, something probably went wrong.");
+            await interaction.reply({ content: "Nepodařilo se nastavit aktivitu. Prosím zkuste to později, nebo kontaktujte vývojáře.", ephemeral: true })
+            return;
+        }
+
+        const activityText = interaction.options.get("activitytext", true).value as string;
+        const activityType = interaction.options.get("type", true)?.value as number;
+        const activityStatus = interaction.options.get("status")?.value as string ?? "online";
+
+        client.user?.setPresence({ activities: [{ name: activityText, type: activityType }], status: activityStatus as PresenceStatusData });
+
+        await interaction.reply({ content: "Aktivita byla úspěšně nastavena!", ephemeral: true });
+    }
+
+} as Command

--- a/src/command/commands/activity.ts
+++ b/src/command/commands/activity.ts
@@ -38,15 +38,13 @@ export default {
                 { name: "Invisible", value: "invisible" },
                 { name: "Do Not Disturb", value: "dnd" },
             )
-        ),
-    //todo: add translations to the command options
+        ),    
 
     call: async (interaction: CommandInteraction, settings: BotSettings, client: Client) => {
 
-        //shouldn't really happen, but TS screams at me violently if it's not here
         if (client.user == null) {
             console.log("Client.user is null, something probably went wrong.");
-            await interaction.reply({ content: "Nepodařilo se nastavit aktivitu. Prosím zkuste to později, nebo kontaktujte vývojáře.", ephemeral: true })
+            await interaction.reply({ content: "Nepodařilo se nastavit aktivitu. Prosím zkuste to později, nebo kontaktujte administrátora.", ephemeral: true })
             return;
         }
 
@@ -63,7 +61,7 @@ export default {
             if (err) throw err;
             let envLines = data.toString().split('\n');
 
-            envLines = envLines.filter(x => !x.includes("ACTIVITY")); //filter out all the lines about activity to delete (and esentially rewrite them)
+            envLines = envLines.filter(x => !x.startsWith("ACTIVITY_")); //filter out all the lines about activity to delete (and esentially rewrite them)
 
             envLines.push(`ACTIVITY_TYPE=${activityType}`);
             envLines.push(`ACTIVITY_STATUS=${activityStatus}`);

--- a/src/command/commands/bonk.ts
+++ b/src/command/commands/bonk.ts
@@ -1,4 +1,4 @@
-import {CommandInteraction, MessageReaction, SlashCommandBuilder, User} from "discord.js"
+import {CommandInteraction, MessageReaction, SlashCommandBuilder, User, Client} from "discord.js"
 import Command from "../command"
 import {BotSettings} from "../../bot";
 
@@ -20,7 +20,7 @@ export default {
     
     requiredPermissions: ["SendMessages"],
 
-    call: async (interaction: CommandInteraction, settings: BotSettings) => {
+    call: async (interaction: CommandInteraction, settings: BotSettings, client: Client) => {
         if (!interaction.guild) return;
         if (!interaction.channel) return;
 

--- a/src/command/commands/help.ts
+++ b/src/command/commands/help.ts
@@ -1,4 +1,4 @@
-import {CommandInteraction, SlashCommandBuilder} from "discord.js"
+import {CommandInteraction, SlashCommandBuilder, Client} from "discord.js"
 import Command from "../command"
 import {BotSettings} from "../../bot";
 
@@ -7,7 +7,7 @@ export default {
         .setName("help")
         .setDescription("Zobrazí všechny dostupné commandy."),
     
-    call: async (interaction: CommandInteraction, settings: BotSettings) => {
+    call: async (interaction: CommandInteraction, settings: BotSettings, client: Client) => {
         let fields = settings.commands.map(command => {
             return {
                 name: command.builder.name,

--- a/src/command/commands/ping.ts
+++ b/src/command/commands/ping.ts
@@ -1,4 +1,4 @@
-import {CommandInteraction, SlashCommandBuilder} from "discord.js"
+import {CommandInteraction, SlashCommandBuilder, Client} from "discord.js"
 import Command from "../command"
 import {BotSettings} from "../../bot";
 
@@ -8,7 +8,7 @@ export default {
         .setDescription("Zobrazí odezvu mezi botem a Discordem."),
 
 
-    call: async (interaction: CommandInteraction, settings: BotSettings) => {
+    call: async (interaction: CommandInteraction, settings: BotSettings, client: Client) => {
         await interaction.reply({
             embeds: [
                 {

--- a/src/command/commands/purge.ts
+++ b/src/command/commands/purge.ts
@@ -1,4 +1,4 @@
-import {CommandInteraction, SlashCommandBuilder, TextChannel} from "discord.js"
+import {CommandInteraction, SlashCommandBuilder, TextChannel, Client} from "discord.js"
 import Command from "../command"
 import {BotSettings} from "../../bot";
 
@@ -17,7 +17,7 @@ export default {
     guildOnly: true,
     requiredPermissions: ["ManageMessages"],
 
-    call: async (interaction: CommandInteraction, settings: BotSettings) => {
+    call: async (interaction: CommandInteraction, settings: BotSettings, client: Client) => {
         const count = interaction.options.get("count", true).value as number;
 
         if (!interaction.guild) return;

--- a/src/command/commands/say.ts
+++ b/src/command/commands/say.ts
@@ -1,4 +1,4 @@
-import {CommandInteraction, SlashCommandBuilder} from "discord.js"
+import {CommandInteraction, SlashCommandBuilder, Client} from "discord.js"
 import Command from "../command"
 import {BotSettings} from "../../bot";
 
@@ -16,7 +16,7 @@ export default {
 
     requiredPermissions: ["ManageMessages"],
 
-    call: async (interaction: CommandInteraction, settings: BotSettings) => {
+    call: async (interaction: CommandInteraction, settings: BotSettings, client: Client) => {
         const message = interaction.options.get("message", true).value as string;
 
         await interaction.reply(message);

--- a/src/command/commands/slap.ts
+++ b/src/command/commands/slap.ts
@@ -1,4 +1,4 @@
-import { CommandInteraction, SlashCommandBuilder, User, AttachmentBuilder, GuildMember } from "discord.js"
+import { CommandInteraction, SlashCommandBuilder, User, AttachmentBuilder, GuildMember, Client} from "discord.js"
 import Command from "../command"
 import { BotSettings } from "../../bot";
 import Jimp from 'jimp';
@@ -15,7 +15,7 @@ export default {
         ),
 
 
-    call: async (interaction: CommandInteraction, settings: BotSettings) => {
+    call: async (interaction: CommandInteraction, settings: BotSettings, client: Client) => {
         //Added variables because of TS compilation error :)
         let opUser = interaction.member?.user;
         let opMember = interaction.member;

--- a/src/command/commands/vote.ts
+++ b/src/command/commands/vote.ts
@@ -10,7 +10,8 @@ import {
     CollectorFilter,
     Interaction,
     MessageComponentInteraction,
-    CommandInteraction
+    CommandInteraction,
+    Client
 } from "discord.js"
 import Command from "../command"
 import {BotSettings} from "../../bot";
@@ -32,7 +33,7 @@ export default {
             .setRequired(true)
         ),
 
-    call: async (interaction: CommandInteraction, settings: BotSettings) => {
+    call: async (interaction: CommandInteraction, settings: BotSettings, client: Client) => {
         if (!interaction.guild) return;
         if (!interaction.channel) return;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import say from "./command/commands/say";
 import vote from "./command/commands/vote";
 import help from "./command/commands/help";
 import slap from "./command/commands/slap";
+import activity from "./command/commands/activity";
 
 import { voice } from "./module/modules/voice";
 
@@ -17,7 +18,8 @@ bot({
         say,
         vote,
         help,
-        slap
+        slap,
+        activity
     ],
     modules: [
         voice

--- a/src/interaction/handler.ts
+++ b/src/interaction/handler.ts
@@ -1,7 +1,7 @@
-import { CommandInteraction, GuildMemberRoleManager, Interaction, InteractionType } from "discord.js";
+import { CommandInteraction, GuildMemberRoleManager, Interaction, InteractionType, Client } from "discord.js";
 import { BotSettings } from "../bot";
 
-export default (settings: BotSettings, interaction: Interaction) => {
+export default (settings: BotSettings, interaction: Interaction, client: Client) => {
  
     if(interaction.type === InteractionType.ApplicationCommand) {
         console.log(`Recieved command interaction for ${interaction.commandName}.`);
@@ -40,7 +40,7 @@ export default (settings: BotSettings, interaction: Interaction) => {
         }
 
 
-        command.call(commandInteraction, settings);
+        command.call(commandInteraction, settings, client);
     } else {
         
     }


### PR DESCRIPTION
This PR implements the `/activity` command and closes #3 

Note: The change of status (dnd/idle/online/invis) sometimes takes some time to actually appear on discord, so don't stress out if the bot appears to be 'online' after a startup/after running the command that changes the status. Only real reason for this, I can think of, is "Discord ¯\\\_(ツ)_/¯"